### PR TITLE
添加修改 Transaction 支持

### DIFF
--- a/beancount_mcp/entry_editor.py
+++ b/beancount_mcp/entry_editor.py
@@ -1,0 +1,63 @@
+from beancount import loader
+from beancount.core import data as d
+from beancount.parser.printer import EntryPrinter
+from beancount.parser.parser import parse_string
+
+from beancount_mcp.text_editor import ChangeSet, ChangeType, TextEditor
+
+
+class EntryEditor:
+    """A class to edit entries in a Beancount file.
+
+    This class provides methods to edit entries by their unique identifier or by their index.
+    It also provides a method to save the changes made to the entries.
+    """
+
+    def __init__(self):
+        self._entry_printer = EntryPrinter()
+
+    def replace_entry(self, old_entry: d.Directive, new_entry: d.Directive):
+        """Replace an entry with a new one."""
+        # Implementation of the replace_entry method
+
+        new_entry_text = self._entry_printer(new_entry) + "\n"
+        self.replace_entry_with_string(old_entry, new_entry_text, False)
+
+    def replace_entry_with_string(
+        self, old_entry: d.Directive, new_entry_text: str, validate_syntax: bool = True
+    ):
+        """Replace an entry with a new one using a string in beancount syntax."""
+        # Implementation of the replace_entry_with_string method
+        if validate_syntax:
+            _, errors, _ = parse_string(new_entry_text)
+            if errors:
+                raise ValueError(
+                    f"Encountered errors while parsing the new entry: {errors}"
+                )
+
+        lineno_range = self._infer_lineno_range(old_entry)
+        filename = old_entry.meta["filename"]
+
+        if not new_entry_text.endswith("\n\n"):
+            new_entry_text = new_entry_text.rstrip("\n") + "\n\n"
+
+        change = ChangeSet(
+            ChangeType.REPLACE,
+            lineno_range,
+            [new_entry_text],
+        )
+        editor = TextEditor(filename)
+        editor.edit(change)
+        editor.save_changes()
+
+    def _infer_lineno_range(self, entry: d.Directive) -> tuple[int, int]:
+        file_name = entry.meta["filename"]
+        start_lineno = entry.meta["lineno"]
+        all_entries, _, _ = loader.load_file(file_name)
+        end_lineno = 0
+        for e in all_entries:
+            lineno = e.meta.get("lineno", 0)
+            if lineno > start_lineno and (lineno < end_lineno or end_lineno == 0):
+                end_lineno = lineno
+
+        return start_lineno - 1, end_lineno - 1

--- a/beancount_mcp/server.py
+++ b/beancount_mcp/server.py
@@ -13,6 +13,7 @@ from typing import Dict, List, Any, Optional
 from beancount import loader
 from beanquery.query import run_query
 from beancount.core import data, getters
+from beancount.core.compare import hash_entry
 from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler
 from mcp.server.fastmcp import FastMCP
@@ -159,7 +160,7 @@ class BeancountMCPServer:
             raise ValueError("Transaction ID is required")
 
         for entry in self.entries:
-            if isinstance(entry, data.Transaction) and entry.meta.get("id") == tx_id:
+            if isinstance(entry, data.Transaction) and hash_entry(entry) == tx_id:
                 filename = entry.meta.get("filename")
                 lineno = entry.meta.get("lineno")
 

--- a/beancount_mcp/text_editor.py
+++ b/beancount_mcp/text_editor.py
@@ -1,0 +1,227 @@
+# Text file editor
+
+
+from dataclasses import dataclass
+import enum
+from math import inf
+from pathlib import Path
+from types import NoneType
+from typing import List, Optional, Tuple
+
+
+class ChangeType(enum.Enum):
+    INSERT = 1
+    DELETE = 2
+    REPLACE = 3
+    APPEND = 4
+
+
+@dataclass
+class ChangeSet:
+    """
+    Represents a change set that describes a modification to a text file.
+
+    Attributes:
+        type (ChangeType): The type of change.
+
+        position (int | Tuple[int, int] | NoneType): The position of the change.
+            For INSERT type, it should be an integer representing the position to insert the content.
+            For DELETE and REPLACE types, it should be a tuple of two integers representing the range to delete or replace.
+            For APPEND type, it should be None, as appending is only supported at the end of the file.
+
+            The line numbers are 0-indexed. When the specified position is negative,
+            it is interpreted as a relative position from the end of the file:
+            e.g. (pos, -1) means every line from pos to the end of the file, inclusive;
+            (pos, -2) means every line from pos to the second last line, etc.
+
+        content (Optional[List[str]]): The content to be inserted, replaced, or appended.
+            This attribute is required for INSERT, REPLACE, and APPEND types.
+    """
+
+    type: ChangeType
+    position: int | Tuple[int, int] | NoneType = None
+    content: Optional[List[str]] = None
+
+    def __post_init__(self):
+        # Verify content
+        if (
+            self.type in {ChangeType.INSERT, ChangeType.REPLACE, ChangeType.APPEND}
+            and self.content is None
+        ):
+            raise ValueError(f"content is required for {self.type}")
+
+        # Verify position
+        if self.type in {ChangeType.INSERT}:
+            assert self.position is not None and isinstance(
+                self.position, int
+            ), f"position must be an integer for {self.type}"
+        elif self.type in {ChangeType.DELETE, ChangeType.REPLACE}:
+            assert (
+                self.position is not None
+                and isinstance(self.position, tuple)
+                and len(self.position) == 2
+            ), f"position must be a tuple of two integers for {self.type} with (begin, end)"
+
+        if self.type in {ChangeType.APPEND}:
+            assert (
+                self.position is None
+            ), f"position must be None for {self.type}, as we only support appending to the end of the file."
+
+        assert isinstance(
+            self.content, list | NoneType
+        ), f"content must be a list of strings for {self.type}"
+
+    def __repr__(self) -> str:
+        return f"ChangeSet(\ntype={self.type},\nposition={self.position},\ncontent={self.content})"
+
+
+class TextEditor:
+    def __init__(self, file_path: str, encoding: str = "utf-8") -> None:
+        """
+        Initialize a TextEditor with given file path.
+
+        Args:
+            file_path (str): The path to the file.
+
+        Raises:
+            AssertionError: If the file does not exist.
+        """
+        self._file_path = Path(file_path)
+        self._encoding = encoding
+        self._lines = self._read_file(file_path)
+        self._file_n_lines = len(self._lines)
+        assert self._file_path.exists(), f"File {file_path} does not exist."
+        self._changes = []
+
+    def _read_file(self, file_path: str) -> List[str]:
+        with open(file_path, "r", encoding=self._encoding) as file:
+            lines = file.readlines()
+        lines.append(
+            ""
+        )  # note: we add this empty line to be able to address the position after the last line with -1
+        return lines
+
+    def edit(self, changes: List[ChangeSet] | ChangeSet) -> None:
+        """
+        Applies the given changes to the text editor.
+
+        Args:
+            changes (List[ChangeSet] | ChangeSet): The changes to be applied. It can be a single ChangeSet or a list of ChangeSet objects.
+
+        Returns:
+            None
+        """
+        if isinstance(changes, ChangeSet):
+            changes = [changes]
+        self._changes.extend(changes)
+
+    def _get_position_tuple(self, change: ChangeSet) -> Tuple[int, int]:
+        # convert relative positions to their absolute values
+        if change.type == ChangeType.INSERT:
+            pos_tuple = (change.position, change.position)
+        elif change.type == ChangeType.DELETE or change.type == ChangeType.REPLACE:
+            pos_tuple = change.position
+        else:
+            pos_tuple = (inf, inf)
+
+        if pos_tuple[0] < 0:
+            pos_tuple = (self._file_n_lines + pos_tuple[0], pos_tuple[1])
+        if pos_tuple[1] < 0:
+            pos_tuple = (pos_tuple[0], self._file_n_lines + pos_tuple[1])
+
+        return pos_tuple
+
+    def _sort_changes_by_position(self):
+        self._changes.sort(key=self._get_position_tuple)
+
+    def _check_changes_non_overlapping(self):
+        for idx in range(len(self._changes) - 1):
+            edit_begin, edit_end = self._get_position_tuple(self._changes[idx])
+            next_begin, next_end = self._get_position_tuple(self._changes[idx + 1])
+            assert (
+                not edit_begin <= next_begin < edit_end
+            ), f"Changes {self._changes[idx]} and {self._changes[idx + 1]} are overlapping."
+
+            if edit_begin == edit_end:
+                assert (
+                    not next_begin == next_end == edit_begin
+                ), f"Double insertion at position {edit_begin} detected."
+
+    def _check_range_validity(self, line_count: int):
+        for change in self._changes:
+            position = self._get_position_tuple(change)
+            assert position == (inf, inf) or (
+                0 <= position[0] <= position[1] < line_count
+            ), f"Change {change} is invalid."
+
+    def save_changes(self, to_path: Optional[str] = None):
+        """
+        Saves the changes made to the file.
+
+        Args:
+            to_path (Optional[str]): The path to save the file. If not provided, the changes will be saved to the original file path.
+
+        Returns:
+            None
+        """
+
+        lines = self._lines
+
+        self._sort_changes_by_position()
+        self._check_changes_non_overlapping()
+        self._check_range_validity(len(lines))
+
+        edited_lines = []
+
+        change_idx = 0
+        line_idx = 0
+        while (
+            line_idx < len(lines) - 1
+        ):  # ignore the last empty line added when reading
+            # No more changes to apply
+            if change_idx >= len(self._changes):
+                edited_lines.extend(lines[line_idx:])
+                break
+
+            change_begin, change_end = self._get_position_tuple(
+                self._changes[change_idx]
+            )
+
+            # Next change is append
+            if change_begin == inf:
+                edited_lines.extend(lines[line_idx:])
+                edited_lines.extend(self._changes[change_idx].content)
+                break
+
+            # Next change is after this line
+            if line_idx < change_begin:
+                edited_lines.extend(lines[line_idx:change_begin])
+                line_idx = change_begin
+                continue
+
+            # Next change is on this line
+            if self._changes[change_idx].type == ChangeType.INSERT:
+                edited_lines.extend(self._changes[change_idx].content)
+                change_idx += 1
+                continue
+            elif self._changes[change_idx].type == ChangeType.DELETE:
+                line_idx = change_end
+                change_idx += 1
+                continue
+            elif self._changes[change_idx].type == ChangeType.REPLACE:
+                edited_lines.extend(self._changes[change_idx].content)
+                line_idx = change_end
+                change_idx += 1
+                continue
+            elif self._changes[change_idx].type == ChangeType.APPEND:
+                edited_lines.append(self._changes[change_idx].content)
+                change_idx += 1
+                continue
+            else:
+                assert False, f"Unexpected change type {self._changes[change_idx].type}"
+
+        save_path = to_path if to_path is not None else self._file_path
+        with open(save_path, "w", encoding=self._encoding) as file:
+            file.writelines(edited_lines)
+
+

--- a/uv.lock
+++ b/uv.lock
@@ -65,7 +65,7 @@ wheels = [
 
 [[package]]
 name = "beancount-mcp"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "beancount" },


### PR DESCRIPTION
可以通过调用 `beancount_replace_transaction` 修改已有 transaction。

修正了已有通过 id 查找 transaction 的问题，因为 beancount bql 是用 hash 来计算 id，id 值不存在 meta 里。